### PR TITLE
feat(foreground-window-mean): Window sum calculation

### DIFF
--- a/foreground.py
+++ b/foreground.py
@@ -30,7 +30,7 @@ class MedianForegroundEstimation:
 class MOG2():
     def __init__(self,**kwargs):
         self.fgbg = cv.createBackgroundSubtractorMOG2(**kwargs)
-    
+
     def __call__(self, frame):
         fgmask = self.fgbg.apply(frame)
         return fgmask
@@ -42,13 +42,13 @@ class PESMODForegroundEstimation():
         self.neighborhood_matrix = neighborhood_matrix
         self.frames_history = None
         self.num_frames = num_frames
-    
+
     def __call__(self, frame):
         if self.frames_history is None:
             self.frames_history = np.expand_dims(frame,axis=0)
-            self.window_sum = self.frames_history[-1].copy().astype(np.int32)
+            self.window_sum = self.frames_history[-1].astype(np.int32)
             return frame
-        
+
         else:
 
             filter_w, filter_h = self.neighborhood_matrix
@@ -63,7 +63,7 @@ class PESMODForegroundEstimation():
             foreground = np.abs(background_patches.reshape(-1) - np.repeat(frame, filter_w * filter_h)).reshape(w, h, -1).min(axis=2).astype(np.uint8)
 
             self.frames_history = np.append(self.frames_history,np.expand_dims(frame, axis=0), axis=0)
-            
+
             if self.frames_history.shape[0]> self.num_frames:
                 self.window_sum -= self.frames_history[0]
                 self.frames_history = self.frames_history[1:]


### PR DESCRIPTION
Instead of recalculating the sum of **frames_history** every time, which takes O(len(frames_history)), 
we:
1. Store the sum
2. Add new frame to the sum
3. Remove an old frame from the sum (If it's not part of the **num frames**)

Which will be O(1) per frame, on the sum.

Note:
- Why cast to np.uint32? So we won't get buffer overflow, Thanks 🍺 man 😄 

**Performance for input_video.mkv, what we had**:
![sharon_vmd](https://github.com/sharon200102/VMD/assets/9656369/27a7d0e3-2309-4c43-b1dd-7912d023c675)

**After using window sum**
![sharon_vmd_window](https://github.com/sharon200102/VMD/assets/9656369/dfab659c-0e45-4580-bc3c-71a6f3559409)

How much time the **window sum** logic takes
![sharon_vmd_window_performance](https://github.com/sharon200102/VMD/assets/9656369/ee4aa23e-e03e-4bee-af86-a3791e454940)
