### PR TITLE
changed default yaml

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -23,7 +23,9 @@ binarizer:
 
 detector:
   detector_name: 'DetectionsFromContours'
-    
+  detector_params:
+    bbox_format: 'yolo'
+    bbox_col_names: ["xRelative","yRelative","width","height"]
 
 foreground_estimator:
   foreground_estimator_name: 'PESMODForegroundEstimation'

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -12,7 +12,7 @@ stabilizer:
 
   
 binarizer:
-  binarizer_name: 'DilateErodeBinarizer'
+  binarizer_name: 'NormalizedDilateErodeBinarizer'
   binarizer_params:
     dilate_kwargs:
       iterations: 1


### PR DESCRIPTION
Replaced bineraizer. Because Sharon and Or said it's better than the non normalized binerazier.
We need to predict normalized bboxes, because we want to have an option to work with any resized image.
